### PR TITLE
Close rows in encodeRows

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,8 @@ func debug(v interface{}) {
 }
 
 func encodeRows(rows *sql.Rows) ([]interface{}, error) {
+	defer rows.Close()
+
 	cols, err := rows.Columns()
 	columns := make([]transit.Keyword, len(cols))
 	for i, col := range cols {


### PR DESCRIPTION
The `.Close()` call was missing and was likely causing memory leaks.

See https://github.com/babashka/pod-babashka-go-sqlite3/issues/36